### PR TITLE
Minor improvements and fix TestParseColor

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -18,6 +18,8 @@ type Color interface {
 	String() string
 	IsLight() bool // http://stackoverflow.com/a/24213274/3158232 and http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
 	IsDark() bool  //for perceived luminance, not strict math
+	RGBA() (r, g, b, a uint32)
+	Equal(Color) bool
 }
 
 // Parse parses an unknown color type to it's appropriate type, or returns a ErrBadColor

--- a/colors.go
+++ b/colors.go
@@ -12,13 +12,30 @@ var (
 
 // Color is the base color interface from which all others ascribe to
 type Color interface {
+	// ToHEX converts the Color interface to a concrete HEXColor
 	ToHEX() *HEXColor
+
+	// ToRGB converts the Color interface to a concrete RGBColor
 	ToRGB() *RGBColor
+
+	// ToRGBA converts the Color interface to a concrete RGBAColor
 	ToRGBA() *RGBAColor
+
+	// String returns the string representation of the Color
 	String() string
-	IsLight() bool // http://stackoverflow.com/a/24213274/3158232 and http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
-	IsDark() bool  //for perceived luminance, not strict math
+
+	// IsLight returns whether the color is perceived to be a light color
+	// http://stackoverflow.com/a/24213274/3158232 and http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
+	IsLight() bool
+
+	// IsDark returns whether the color is perceived to be a dark color
+	//for perceived luminance, not strict math
+	IsDark() bool
+
+	// RGBA implements std-lib color.Color interface
 	RGBA() (r, g, b, a uint32)
+
+	// Equal reports whether the colors are the same
 	Equal(Color) bool
 }
 

--- a/colors_test.go
+++ b/colors_test.go
@@ -208,19 +208,75 @@ func TestColorConversionFromStdColor(t *testing.T) {
 	Equal(t, rgba.ToHEX().String(), "#5f55f5")
 }
 
+func TestColorConversionFromToStdColor(t *testing.T) {
+
+	hex, _ := ParseHEX("#5f55f5")
+	r, g, b, a := hex.RGBA()
+
+	Equal(t, r, uint32(95))
+	Equal(t, g, uint32(85))
+	Equal(t, b, uint32(245))
+	Equal(t, a, uint32(1))
+
+	rgba, _ := RGBA(242, 217, 128, 1)
+	r, g, b, a = rgba.RGBA()
+
+	Equal(t, r, uint32(242))
+	Equal(t, g, uint32(217))
+	Equal(t, b, uint32(128))
+	Equal(t, a, uint32(1))
+
+	rgb, _ := RGB(242, 217, 128)
+	r, g, b, a = rgb.RGBA()
+
+	Equal(t, r, uint32(242))
+	Equal(t, g, uint32(217))
+	Equal(t, b, uint32(128))
+	Equal(t, a, uint32(1))
+}
+
+func TestColorEqual(t *testing.T) {
+
+	hex, _ := ParseHEX("#5f55f5")
+	rgb, _ := RGB(95, 85, 245)
+	rgba, _ := RGBA(95, 85, 245, 1)
+
+	Equal(t, hex.Equal(hex), true)
+	Equal(t, hex.Equal(rgb), true)
+	Equal(t, hex.Equal(rgba), true)
+	Equal(t, rgb.Equal(rgb), true)
+	Equal(t, rgb.Equal(hex), true)
+	Equal(t, rgb.Equal(rgba), true)
+	Equal(t, rgba.Equal(rgba), true)
+	Equal(t, rgba.Equal(rgb), true)
+	Equal(t, rgba.Equal(hex), true)
+
+	hex2, _ := ParseHEX("#5f55f4")
+	rgb2, _ := RGB(95, 87, 245)
+	rgba2, _ := RGBA(93, 85, 245, 1)
+
+	Equal(t, hex2.Equal(rgb2), false)
+	Equal(t, hex2.Equal(rgba2), false)
+	Equal(t, rgb2.Equal(hex2), false)
+	Equal(t, rgb2.Equal(rgba2), false)
+	Equal(t, rgba2.Equal(rgb2), false)
+	Equal(t, rgba2.Equal(hex2), false)
+
+}
+
 func TestParseColor(t *testing.T) {
 
 	color, _ := Parse("#FFF")
 	NotEqual(t, color, nil)
-	Equal(t, reflect.TypeOf(color), reflect.TypeOf(&HEXColor{}))
+	Equal(t, reflect.TypeOf(color) == reflect.TypeOf(&HEXColor{}), true)
 
 	color, _ = Parse("rgb(95,85,245)")
 	NotEqual(t, color, nil)
-	Equal(t, reflect.TypeOf(color), reflect.TypeOf(&RGBColor{}))
+	Equal(t, reflect.TypeOf(color) == reflect.TypeOf(&RGBColor{}), true)
 
 	color, _ = Parse("rgba(95,85,245,1)")
 	NotEqual(t, color, nil)
-	Equal(t, reflect.TypeOf(color), reflect.TypeOf(&RGBAColor{}))
+	Equal(t, reflect.TypeOf(color) == reflect.TypeOf(&RGBAColor{}), true)
 
 	color, _ = Parse("#ff")
 	Equal(t, color, nil)
@@ -230,7 +286,7 @@ func TestParseColor(t *testing.T) {
 
 	c, err := Parse("rgba(127,34,94,0.534556634531)")
 	Equal(t, err, nil)
-	Equal(t, reflect.TypeOf(c), reflect.TypeOf(&RGBAColor{}))
+	Equal(t, reflect.TypeOf(c) == reflect.TypeOf(&RGBAColor{}), true)
 }
 
 func TestIsLightIsDark(t *testing.T) {

--- a/hex.go
+++ b/hex.go
@@ -79,3 +79,13 @@ func (c *HEXColor) IsLight() bool {
 func (c *HEXColor) IsDark() bool {
 	return !c.IsLight()
 }
+
+// RGBA implements color.Color interface
+func (c *HEXColor) RGBA() (r, g, b, a uint32) {
+	return c.ToRGBA().RGBA()
+}
+
+// Equal reports whether c is the same color as d
+func (c *HEXColor) Equal(d Color) bool {
+	return c.ToRGBA().String() == d.ToRGBA().String()
+}

--- a/rgb.go
+++ b/rgb.go
@@ -101,3 +101,13 @@ func (c *RGBColor) IsLight() bool {
 func (c *RGBColor) IsDark() bool {
 	return !c.IsLight()
 }
+
+// RGBA implements color.Color interface
+func (c *RGBColor) RGBA() (r, g, b, a uint32) {
+	return c.ToRGBA().RGBA()
+}
+
+// Equal reports whether c is the same color as d
+func (c *RGBColor) Equal(d Color) bool {
+	return c.ToRGBA().String() == d.ToRGBA().String()
+}

--- a/rgba.go
+++ b/rgba.go
@@ -157,3 +157,13 @@ func (c *RGBAColor) IsLightAlpha(bg Color) bool {
 func (c *RGBAColor) IsDarkAlpha(bg Color) bool {
 	return !c.IsLightAlpha(bg)
 }
+
+// RGBA implements color.Color interface
+func (c *RGBAColor) RGBA() (r, g, b, a uint32) {
+	return uint32(c.R), uint32(c.G), uint32(c.B), uint32(c.A)
+}
+
+// Equal reports whether c is the same color as d
+func (c *RGBAColor) Equal(d Color) bool {
+	return c.ToRGBA().String() == d.ToRGBA().String()
+}


### PR DESCRIPTION
add methods Color.Equal(Color), and also Color.RGBA() to implement stdlib color.Color
add doc to interface methods too
fix TestParseColor, e.g.: `Equal(*testing.T, reflect.TypeOf(&HEXColor{}), reflect.TypeOf(&HEXColor{}))` was reporting false
