### PR TITLE
Fix standard library interface implementation 

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -32,7 +32,8 @@ type Color interface {
 	//for perceived luminance, not strict math
 	IsDark() bool
 
-	// RGBA implements std-lib color.Color interface
+	// RGBA implements std-lib color.Color interface.
+	// It returns the red, green, blue and alpha values for the color. Each value ranges within [0, 0xffff]
 	RGBA() (r, g, b, a uint32)
 
 	// Equal reports whether the colors are the same

--- a/colors_test.go
+++ b/colors_test.go
@@ -209,30 +209,42 @@ func TestColorConversionFromStdColor(t *testing.T) {
 }
 
 func TestColorConversionFromToStdColor(t *testing.T) {
+	// verify that colors are equals
+	equalColors := func(t *testing.T, color Color, stdColor color.Color) {
+		r, g, b, a := color.RGBA()
+		stdR, stdG, stdB, stdA := stdColor.RGBA()
+		Equal(t, r, stdR)
+		Equal(t, g, stdG)
+		Equal(t, b, stdB)
+		Equal(t, a, stdA)
+	}
 
 	hex, _ := ParseHEX("#5f55f5")
 	r, g, b, a := hex.RGBA()
 
-	Equal(t, r, uint32(95))
-	Equal(t, g, uint32(85))
-	Equal(t, b, uint32(245))
-	Equal(t, a, uint32(1))
+	Equal(t, r, uint32(24415))
+	Equal(t, g, uint32(21845))
+	Equal(t, b, uint32(62965))
+	Equal(t, a, uint32(65535))
+	equalColors(t, hex, &color.RGBA{R: 95, G: 85, B: 245, A: 255})
 
-	rgba, _ := RGBA(242, 217, 128, 1)
+	rgba, _ := RGBA(242, 217, 128, 0.4)
 	r, g, b, a = rgba.RGBA()
 
-	Equal(t, r, uint32(242))
-	Equal(t, g, uint32(217))
-	Equal(t, b, uint32(128))
-	Equal(t, a, uint32(1))
+	Equal(t, r, uint32(62194))
+	Equal(t, g, uint32(55769))
+	Equal(t, b, uint32(32896))
+	Equal(t, a, uint32(26214))
+	equalColors(t, rgba, &color.RGBA{R: 242, G: 217, B: 128, A: 102})
 
 	rgb, _ := RGB(242, 217, 128)
 	r, g, b, a = rgb.RGBA()
 
-	Equal(t, r, uint32(242))
-	Equal(t, g, uint32(217))
-	Equal(t, b, uint32(128))
-	Equal(t, a, uint32(1))
+	Equal(t, r, uint32(62194))
+	Equal(t, g, uint32(55769))
+	Equal(t, b, uint32(32896))
+	Equal(t, a, uint32(65535))
+	equalColors(t, rgb, &color.RGBA{R: 242, G: 217, B: 128, A: 255})
 }
 
 func TestColorEqual(t *testing.T) {

--- a/hex.go
+++ b/hex.go
@@ -80,7 +80,8 @@ func (c *HEXColor) IsDark() bool {
 	return !c.IsLight()
 }
 
-// RGBA implements color.Color interface
+// RGBA implements color.Color interface.
+// It returns the red, green, blue and alpha values for the color. Each value ranges within [0, 0xffff]
 func (c *HEXColor) RGBA() (r, g, b, a uint32) {
 	return c.ToRGBA().RGBA()
 }

--- a/rgb.go
+++ b/rgb.go
@@ -102,7 +102,8 @@ func (c *RGBColor) IsDark() bool {
 	return !c.IsLight()
 }
 
-// RGBA implements color.Color interface
+// RGBA implements color.Color interface.
+// It returns the red, green, blue and alpha values for the color. Each value ranges within [0, 0xffff]
 func (c *RGBColor) RGBA() (r, g, b, a uint32) {
 	return c.ToRGBA().RGBA()
 }

--- a/rgba.go
+++ b/rgba.go
@@ -158,9 +158,17 @@ func (c *RGBAColor) IsDarkAlpha(bg Color) bool {
 	return !c.IsLightAlpha(bg)
 }
 
-// RGBA implements color.Color interface
+// RGBA implements color.Color interface.
+// It returns the red, green, blue and alpha values for the color. Each value ranges within [0, 0xffff]
 func (c *RGBAColor) RGBA() (r, g, b, a uint32) {
-	return uint32(c.R), uint32(c.G), uint32(c.B), uint32(c.A)
+	r = uint32(c.R)
+	r |= r << 8
+	g = uint32(c.G)
+	g |= g << 8
+	b = uint32(c.B)
+	b |= b << 8
+	a = uint32(c.A*0xffff + .5)
+	return r, g, b, a
 }
 
 // Equal reports whether c is the same color as d


### PR DESCRIPTION
Fixed `RGBA() (r, g, b, a uint32)` implementation:

- the float64 `A` field (alpha channel in a [0-1] range) is truncated by a int32 cast
- the method should return four values in a 16-bits range, so [0-65535] (see [src/image/color/color.go](https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/image/color/color.go))