### PR TITLE
Fix lint warnings

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// ErrBadColor is the default bad color error
-	ErrBadColor = errors.New("Parsing of color failed, Bad Color")
+	ErrBadColor = errors.New("parsing of color failed, Bad Color")
 )
 
 // Color is the base color interface from which all others ascribe to

--- a/rgb.go
+++ b/rgb.go
@@ -35,11 +35,11 @@ func ParseRGB(s string) (*RGBColor, error) {
 	var isPercent bool
 	vals := rgbCaptureRegex.FindAllStringSubmatch(s, -1)
 
-	if vals == nil || len(vals) == 0 || len(vals[0]) == 0 {
+	if len(vals) == 0 || len(vals[0]) == 0 {
 
 		vals = rgbCapturePercentRegex.FindAllStringSubmatch(s, -1)
 
-		if vals == nil || len(vals) == 0 || len(vals[0]) == 0 {
+		if len(vals) == 0 || len(vals[0]) == 0 {
 			return nil, ErrBadColor
 		}
 

--- a/rgba.go
+++ b/rgba.go
@@ -38,11 +38,11 @@ func ParseRGBA(s string) (*RGBAColor, error) {
 
 	vals := rgbaCaptureRegex.FindAllStringSubmatch(s, -1)
 
-	if vals == nil || len(vals) == 0 || len(vals[0]) == 0 {
+	if len(vals) == 0 || len(vals[0]) == 0 {
 
 		vals = rgbaCapturePercentRegex.FindAllStringSubmatch(s, -1)
 
-		if vals == nil || len(vals) == 0 || len(vals[0]) == 0 {
+		if len(vals) == 0 || len(vals[0]) == 0 {
 			return nil, ErrBadColor
 		}
 


### PR DESCRIPTION
Fixed the following static checks failures:
- should omit nil check; len() for [][]string is defined as zero (S1009)
- error strings should not be capitalized (ST1005)